### PR TITLE
Fix parameterValue missing problem and add annotation for Koa

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ You write something like this:
 const doc = require('test2doc')
 const request = require('supertest') // We use supertest as the HTTP request library
 require('should') // and use should as the assertion library
+
+// If you are using Koa, you should exports app.callback() in your main file
 const app = require('./my-express-app.js')
 
 after(function () {

--- a/apib-generator.js
+++ b/apib-generator.js
@@ -26,7 +26,7 @@ function generateDocForParameters (parameters, indentLevel = 0) {
     const docs = capture.docs(parameters[parameterName])
     const parameterValue = capture.undo(parameters[parameterName])
     document += `${indent(indentLevel + 1)}+ ${parameterName}`
-    if (parameterValue) {
+    if (parameterValue != null) {
       document += `: \`${parameterValue}\``
     }
     let additions = []


### PR DESCRIPTION
Below code will cause a problem of the disapperance of  `parameterValue`, for example when `parameterValue` is 0
```js
if (parameterValue) {
  document += `: \`${parameterValue}\``
}
```

And also I add an annotation for Koa, in Koa.js, you should exports the result of the execuate of app's callback function
```js
const Koa = require('koa')
const app = new Koa()
app.listen(8000)
module.exports = app.callback() // to use this library, this line is necessary in Koa
```
Maybe someone know how to do, but I think adding an annotation is more clearly~