### PR TITLE
convertPath() should replace all occurrences of escaped braces.

### DIFF
--- a/lib/apib-generator.js
+++ b/lib/apib-generator.js
@@ -9,7 +9,7 @@ function convertPath (path, queries) {
   for (const key of keys) {
     parameters[key.name] = `{${key.name}}`
   }
-  path = pathToRegexp.compile(path)(parameters).replace('%7B', '{').replace('%7D', '}')
+  path = pathToRegexp.compile(path)(parameters).replace(/%7B/g, '{').replace(/%7D/g, '}')
   if (queries) {
     const keys = Object.keys(queries)
     if (keys.length) path += `{?${keys.join(',')}}`

--- a/lib/swagger-generator.js
+++ b/lib/swagger-generator.js
@@ -11,7 +11,7 @@ function convertPath (path) {
   for (const key of keys) {
     parameters[key.name] = `{${key.name}}`
   }
-  path = pathToRegexp.compile(path)(parameters).replace('%7B', '{').replace('%7D', '}')
+  path = pathToRegexp.compile(path)(parameters).replace(/%7B/g, '{').replace(/%7D/g, '}')
   return path.startsWith('/') ? path : `/${path}`
 }
 

--- a/test/lib/apib-generator.js
+++ b/test/lib/apib-generator.js
@@ -10,6 +10,7 @@ suite('apib-generator.js', function () {
 
     test('should work is `queries` parameter is omitted', function () {
       generate.convertPath('/user/:userId').should.equal('/user/{userId}')
+      generate.convertPath('/user/:userId/cards/:cardId').should.equal('/user/{userId}/cards/{cardId}')
     })
   })
 

--- a/test/lib/swagger-generator.js
+++ b/test/lib/swagger-generator.js
@@ -6,6 +6,7 @@ suite('swagger-generator.js', function () {
   suite('#convertPath()', function () {
     test('should convert a path-to-regexp style path with queries to a Swagger style url', function () {
       generate.convertPath('/user/:userId').should.equal('/user/{userId}')
+      generate.convertPath('/user/:userId/cards/:cardId').should.equal('/user/{userId}/cards/{cardId}')
     })
   })
 })


### PR DESCRIPTION
Previously, `convertPath` does not replace occurrences of escaped braces (%7B, %7D).
If a string is used for `String#replace`, it only replaces the first occurrence.
This fix is just change the substr to regex.