### PR TITLE
generate group also for group that contains only actions

### DIFF
--- a/lib/apib-generator.js
+++ b/lib/apib-generator.js
@@ -213,8 +213,8 @@ function generate (group) {
         document += `# API Documentation ${group.docs.title}\n\n`
       }
     } else {
-      if (group.depth === 1 && group.children.length) { // is Resource Group
-        document += `# Group ${group.docs.title || 'Untitled'}`
+      if ((group.children.length || group.actions.length)) { // is Resource Group
+        document += `${group.depth === 1 ? '#' : '##'} Group ${group.docs.title || 'Untitled'}`
         if (group.docs.version) document += ` ${group.docs.version}`
         document += '\n\n'
       } else {


### PR DESCRIPTION
Actually generate a group only if a group contains children group. It should generate a group for a group that contains only actions, too